### PR TITLE
Removed override notation for deprecated method (createJSModules) of …

### DIFF
--- a/android/src/main/java/cl/json/RNSharePackage.java
+++ b/android/src/main/java/cl/json/RNSharePackage.java
@@ -15,7 +15,7 @@ public class RNSharePackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNShareModule(reactContext));
     }
 
-    @Override
+    // Deprecated from RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
…React Native 0.47.0

https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8